### PR TITLE
[#118695049] Python social auth/redirect scheme setting

### DIFF
--- a/common/djangoapps/third_party_auth/settings.py
+++ b/common/djangoapps/third_party_auth/settings.py
@@ -84,3 +84,6 @@ def apply_settings(django_settings):
         'social.apps.django_app.context_processors.backends',
         'social.apps.django_app.context_processors.login_redirect',
     )
+
+    # Set scheme to use for redirection in python-social-auth
+    django_settings.REDIRECT_IS_HTTPS = settings.FEATURES.get('THIRD_PARTY_AUTH_REDIRECT_IS_HTTPS', False)

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -68,7 +68,8 @@ python-dateutil==2.1
 
 # This module gets monkey-patched in third_party_auth.py to fix a Django 1.8 incompatibility.
 # When this dependency gets upgraded, the monkey patch should be removed, if possible.
-python-social-auth==0.2.12
+# python-social-auth==0.2.12
+-e git+https://github.com/bigdatauniversity/python-social-auth.git#egg=python-social-auth
 
 pytz==2015.2
 pysrt==0.4.7


### PR DESCRIPTION
This story switches the **python-social-auth** package source to a fork version. Also, **REDIRECT_IS_HTTPS** used by the package to enforce the scheme to use is set by getting the value from _lms.env.json_ file.
